### PR TITLE
create_or_update method, plus batch methods for each of the 3 actions

### DIFF
--- a/pythonmarketo/client.py
+++ b/pythonmarketo/client.py
@@ -284,5 +284,5 @@ class MarketoClient:
         }
         data = HttpLib().post("https://" + self.host + "/rest/v1/leads.json" , args, data)
         if not data['success'] : raise MarketoException(data['errors'][0])
-        return data['result'][0]['status']
+        return data['result'][0]
         


### PR DESCRIPTION
Added create_or_update method for leads to upsert.
Added methods for create, update, and create_or_update actions, to upload multiple leads at once. Note there is no handling for the API limit of 300 per request / 1MB payload cap.
